### PR TITLE
Enable the architecture-standards plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "architecture-standards": {
+      "source": { "source": "github", "repo": "konradcinkusz/architecture-standards" }
+    }
+  },
+  "enabledPlugins": {
+    "architecture-core@architecture-standards": true
+  }
+}


### PR DESCRIPTION
## What changed

Added `.claude/settings.json`, registering `konradcinkusz/architecture-standards` as
a known plugin marketplace and enabling its `architecture-core` plugin. Any Claude
Code session opened against this repo now auto-installs that plugin at startup — the
constitution, the review/modernize/recover playbook, and the repository baseline —
without needing the standards repo attached as a separate source each time.

## Why

This repo already holds itself to `00-REFERENCE-ARCHITECTURE.md` as its worked
example, and records deviations in `docs/DEVIATIONS.md`. Declaring the marketplace
just makes that dependency explicit and mechanical instead of relying on a human to
remember to attach the standards repo.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched

## Verification

- [x] Fresh-clone check still true: `git clone && dotnet run` works with **zero**
      credentials — unaffected by this change, no code touched
- [ ] Secret scan (`scripts/scan-secrets.sh`) — could not run in this environment
      (neither `gitleaks` nor a Docker daemon available); the diff is a single JSON
      file naming a public repo, no secrets in it. Flagging so CI's own secret-scan
      job is the actual gate here, not this local run.

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials — including in comments and test fixtures
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQpbAudPktt7EMV1utPSi4)_