### PR TITLE
Restrict workflow triggers to manual dispatch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,6 @@ name: CI
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    # Feature branches are included deliberately. This repository is built phase
-    # by phase on `claude/**` branches, and lint feedback that only arrives when a
-    # pull request is opened is feedback that arrives after the work is finished.
-    # It is also what makes this workflow's own definition of done checkable:
-    # a workflow that has never executed is a claim, not a control.
-    branches: [main, 'claude/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,13 +19,6 @@ name: CodeQL
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main, 'claude/**']
-  schedule:
-    # Mondays 04:00 UTC. Rule sets change under a codebase that has not.
-    - cron: '0 4 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,10 +21,6 @@
 name: Nightly evals
 
 on:
-  schedule:
-    # 02:30 UTC. Late enough that a day's merges are in, early enough that the
-    # result is waiting rather than arriving mid-morning.
-    - cron: '30 2 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/production-loop.yml
+++ b/.github/workflows/production-loop.yml
@@ -31,9 +31,6 @@ name: Production loop
 # ═══════════════════════════════════════════════════════════════════════════════
 
 on:
-  schedule:
-    # 04:15 UTC — after the nightly evals, so a morning reader gets both.
-    - cron: '15 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,14 +29,6 @@ name: Secret Scan
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main, 'claude/**']
-  schedule:
-    # Mondays 05:30 UTC — before the Dependabot batch, so a rule-set change that
-    # turns an old commit into a finding is not confused with a dependency bump.
-    - cron: '30 5 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

Removed the `pull_request`, `push`, and `schedule` triggers from `ci.yml`, `codeql.yml`, `secret-scan.yml`, `nightly.yml`, and `production-loop.yml`. Each now only runs via `workflow_dispatch`. `flyio.yml` (the tag-driven Fly deploy) and `azure.yml` (already `workflow_dispatch`-only) are untouched, so deployment to Fly remains automatic on `v*` tags — that was the one exception requested.

## Why

Per request: no workflow in this repository should fire automatically except the Fly deployment. This is a trigger-only change — no job logic, gating, or step behavior was modified.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched

## Eval impact

- [x] Constraint scenarios: 100% pass (hard gate — no exceptions, no "flaky")

N/A — no eval-triggering paths touched; this PR only edits `on:` blocks in `.github/workflows/`.

## Verification

N/A for build/test/eval — no application code changed. YAML validity of every edited workflow file was checked with `yaml.safe_load` before pushing.

- [x] Fresh-clone check still true: `git clone && dotnet run` works with **zero** credentials (unaffected by this change)

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials — including in comments and test fixtures
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

## Note for reviewers

`ci.yml`'s `coupling` job and its "sticky PR comment" step are gated on `github.event_name == 'pull_request'`. With the `pull_request` trigger removed, those code paths are now unreachable via `workflow_dispatch` (their `if:` conditions simply evaluate false) — they weren't touched, but they also won't run automatically anymore. Flag if you'd like those trimmed or reworked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKF1eVjwQwPi996twNznWK)_