### PR TITLE
ci: grade each commit once — drop the claude/** push trigger, keep the PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,16 @@ on:
   pull_request:
     branches: [main]
   push:
-    # Feature branches are included deliberately. This repository is built phase
-    # by phase on `claude/**` branches, and lint feedback that only arrives when a
-    # pull request is opened is feedback that arrives after the work is finished.
-    # It is also what makes this workflow's own definition of done checkable:
-    # a workflow that has never executed is a claim, not a control.
-    branches: [main, 'claude/**']
+    # `main` only, deliberately — this used to include `claude/**`, and the
+    # reason it no longer does is written down rather than implied by the diff.
+    # A branch with an open pull request already gets a run on every push,
+    # through the `pull_request` trigger; the `claude/**` push event graded the
+    # same commit a second time, and what the duplicate bought (lint feedback
+    # before a pull request exists) stopped being worth the doubled runs once
+    # every phase landed via a pull request anyway. The post-merge run on
+    # `main` stays: it re-checks the suite on the exact merge commit, which no
+    # pull-request run ever saw.
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

`ci.yml`'s `push` trigger narrows from `[main, 'claude/**']` to `[main]`. The `pull_request` trigger, the post-merge run on `main` and `workflow_dispatch` are untouched, and so are `codeql.yml` and `secret-scan.yml`. The trigger's comment now records the retired trade-off instead of describing the old behaviour.

## Why

A branch with an open pull request already runs the full suite on every push through the `pull_request` trigger (`synchronize`), so the `claude/**` push event graded the same commit a second time. Halving the runs this way keeps everything the repository's story depends on: constraints still hard-block every pull request, the sticky PR comment still carries the diff, the coupling job still runs, and `main` still gets a post-merge run on the exact merge commit no PR run ever saw.

This is the narrow alternative to #22: that PR removes the `pull_request` trigger too, which makes the coupling job and the sticky-comment step unreachable and puts the workflows at odds with what `README.md` and `docs/SPEC.md` §8 claim. Scheduled workflows (`nightly.yml`, `production-loop.yml`) are being disabled from the Actions UI instead, which is reversible without a commit.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched

## Eval impact

No eval-triggering paths touched — the diff is one `on:` block in `.github/workflows/ci.yml`. Which *events* trigger the suite changes; what the suite gates does not.

**Scenario / criteria diff vs baseline:** no eval-triggering paths touched.

## Verification

- [x] Edited workflow parses (`yaml.parse` over the file, clean)
- [x] Eval suite explicitly not applicable — no application code changed
- [x] Fresh-clone check still true: `git clone && dotnet run` works with **zero** credentials (unaffected)

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md` — the PR gate, which is what the standard cares about, is unchanged

## Public-repo checks

- [x] No secrets, tokens, or credentials — including in comments and test fixtures
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWaDDx5a12neo5BmeuP3Eu)_