### PR TITLE
docs(readme): lead with the measuring loop, not with the use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,67 @@ demonstrated on an HR **Absence Concierge**: an agent that books time off, and s
 for a human before it writes anything. The agent is the excuse.
 **The eval bench is the deliverable.**
 
-## The machine does the work; a person keeps the decision
+## How the bench works
 
-An employee types *"I'm sick today and probably tomorrow."* The agent resolves the
-dates against a real working calendar in the employee's timezone, fetches the available
-leave types, checks the existing bookings for conflicts, drafts the request — and
-having done all the work, being entirely confident, **it stops and asks a human**:
+The spec came first; the trace is what gets graded. Everything else is plumbing around
+those two facts.
 
-![The confirmation card: the agent has resolved "I'm sick today and probably tomorrow" into a two-day sick-leave draft, and stopped for approval](docs/assets/confirmation-card.png)
+```mermaid
+flowchart TD
+    spec["<b>docs/SPEC.md</b> — the contract<br/><i>written before the agent</i>"]
+    scen["evals/ — scenarios as YAML<br/>happy · ambiguity · denied ·<br/>adversarial · degradation"]
+    runner["ScenarioRunner<br/>the REAL service, in-process<br/>faults injected at the tool seam"]
+    trace["One captured trace per scenario"]
+    l1["<b>Layer 1</b> — deterministic<br/>no model, no network, no credential"]
+    l2["<b>Layer 2</b> — rubric judge<br/>pinned model, hashed prompt"]
+    gate["CI gates<br/>constraints 100%<br/>behaviours vs baseline"]
 
-That stop is not politeness in a prompt. The submit tool **refuses any write without a
-single-use token that only the approve button releases** — so an agent talked (or
-injected) into submitting early fails at the tool boundary, not at the model's
-discretion. Everything else in this repository exists to *prove* that sentence and its
-neighbours, mechanically, on every change.
+    spec -->|"each behaviour cites its proof"| scen
+    scen --> runner
+    runner --> trace
+    trace --> l1
+    trace --> l2
+    l1 --> gate
+    l2 --> gate
 
-If the demo says one thing to a non-engineer, it is this: AI agents that act on your
-systems can be built so the machine does the work and a person keeps the decision — and
-whether that stays true under prompt edits, model swaps and hostile input is something
-you can measure, not something you trust.
+    classDef star fill:#fdf0d5,stroke:#c8860d,stroke-width:2px,color:#3d2b00
+    class gate star
+```
+
+Top to bottom, that is the whole repository:
+
+1. **The contract, before the code.** [`docs/SPEC.md`](docs/SPEC.md) states the
+   behaviours, the hard constraints and the refusals, and every behaviour cites the
+   scenarios that prove it. It was written and accepted before any agent existed, which
+   is what stops the specification from being back-fitted to whatever got built.
+1. **The dataset is data, not code.** The 35 scenarios under `evals/scenarios/` are
+   YAML — five classes, a shared fictional world plus a per-scenario delta, validated
+   against a [strict JSON Schema](evals/schema/scenario.schema.json) on every push.
+   Nothing in the dataset is .NET-specific; [`evals/README.md`](evals/README.md) is the
+   tour.
+1. **The run is the real service.** `ScenarioRunner` executes the actual agent
+   in-process and injects faults at the tool seam, so a degradation scenario exercises
+   the same code path a real timeout would.
+1. **What gets graded is the trace, never the prose.** One captured trace per scenario:
+   spans, events, tool calls, arguments. That is the interface both layers read, and it
+   is why a green run means something whether a deterministic composer or a language
+   model wrote the sentence.
+1. **Two layers, deliberately unequal.** Layer 1 is deterministic — which tools were
+   called, with what arguments, in what order, and what was **not** done. It needs no
+   model, no network and no credential, which is exactly why it can gate every pull
+   request. Layer 2 is a rubric-anchored judge with a pinned model and a hashed prompt,
+   calibrated against labels before its scores may block anything; on credential-less
+   runs it reports `skipped:no-credential`, never a silent green.
+1. **The gate is where a measurement becomes a decision.** Constraint scenarios
+   hard-block at 100%; behaviour scenarios are compared against a recorded baseline; the
+   pull request gets one comment carrying the diff rather than a dashboard.
+
+That loop is the deliverable. [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md) takes it apart into
+22 diagrams — including [C2](docs/DIAGRAMS.md#c2-layer-1--what-a-deterministic-assertion-actually-reads)
+and [C3](docs/DIAGRAMS.md#c3-layer-2--the-judge-and-why-it-is-pinned) for each layer's
+internals, and
+[C6](docs/DIAGRAMS.md#c6-both-layers-on-one-page--everything-the-trace-is-graded-by)
+for both on one page.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -61,6 +103,39 @@ you can measure, not something you trust.
 Every count above is recomputed in [`docs/FINDINGS.md`](docs/FINDINGS.md), which is the
 one place counts live — a number copied into prose is a number that goes stale on the
 next commit.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## The specimen: an agent that stops
+
+A bench needs something to measure. This one measures an HR **Absence Concierge**,
+chosen because it concentrates every hard property at once: an irreversible write, date
+arithmetic across timezones and holidays, permission rules, a hostile-input surface, and
+an obvious need for a human to say yes.
+
+A user says *"I'm sick today and probably tomorrow"* — or *"book me Friday off"*. The
+agent resolves the dates in the user's timezone, fetches the available leave types,
+checks existing leaves for conflicts, drafts the request, shows a summary and **stops
+for explicit human confirmation**:
+
+![The confirmation card: the agent has resolved "I'm sick today and probably tomorrow" into a two-day sick-leave draft, and stopped for approval](docs/assets/confirmation-card.png)
+
+Only then does it execute the write, and it reports the outcome grounded in what the
+tools actually returned. Denied paths — no permission, unknown leave type, a request
+that is out of scope — refuse cleanly and are asserted twice: the refusal happened,
+*and* the call did not. Tool failures degrade into partial output with a note, never a
+fabricated result and never a silent retry loop.
+
+That stop is not politeness in a prompt. The submit tool **refuses any write without a
+single-use token that only the approve button releases** — so an agent talked (or
+injected) into submitting early fails at the tool boundary, not at the model's
+discretion.
+
+And that is precisely why the agent is the excuse rather than the point. "It stops for a
+human" is a claim, and a claim about agent behaviour is worth exactly what its
+measurement is worth. Everything above this section exists to hold that sentence — and
+every other behaviour the spec states — to a number, on every change, under prompt
+edits, model swaps and hostile input.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -210,21 +285,6 @@ rather than a convenience: it fixes the tool contract outside this repository, s
 payload mapping cannot quietly be redefined to whatever makes a scenario pass. What
 that has *not* bought yet is honest to state — no live server has ever answered this
 client ([D-10](docs/DEVIATIONS.md)).
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-## The agent, in one paragraph
-
-A user says *"I'm sick today and probably tomorrow"* — or *"book me Friday off"*. The
-agent resolves the dates in the user's timezone, fetches the available leave types,
-checks existing leaves for conflicts, drafts the request, shows a summary and **stops
-for explicit human confirmation**. Only then does it execute the write, and it reports
-the outcome grounded in what the tools actually returned. Denied paths — no permission,
-unknown leave type, a request that is out of scope — refuse cleanly and are asserted
-twice: the refusal happened, *and* the call did not. Tool failures degrade into partial
-output with a note, never a fabricated result and never a silent retry loop.
-
-Everything interesting is in the second half of that paragraph.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/scripts/check-diagrams.mjs
+++ b/scripts/check-diagrams.mjs
@@ -19,6 +19,15 @@
  * `a1-`. That keeps the filename free to describe the diagram while the id stays
  * the join key.
  *
+ * The README is the third place, and it is checked differently. It embeds one
+ * diagram — the measuring loop — because a repository whose deliverable is the
+ * loop should draw the loop before it draws anything else, and GitHub renders
+ * Mermaid in a README the same way it does in any other document. It is not a
+ * numbered section, so it cannot join on an id; the rule there is weaker but
+ * still mechanical: every ```mermaid block in README.md must be byte-identical
+ * to some file in docs/diagrams/. Copying a diagram into the README and then
+ * editing one of the two copies is the drift this catches.
+ *
  * Zero dependencies on purpose: this runs in the same job as check-links.mjs,
  * before anything has been installed.
  *
@@ -128,6 +137,53 @@ for (const name of files) {
   }
 }
 
+/** Every ```mermaid block in a document, in order, each ending in a newline. */
+function mermaidBlocks(source) {
+  const blocks = [];
+  let fence = null;
+
+  for (const line of source.split('\n')) {
+    if (fence === null && line.trim() === '```mermaid') {
+      fence = [];
+      continue;
+    }
+
+    if (fence !== null && line.trim() === '```') {
+      blocks.push(`${fence.join('\n')}\n`);
+      fence = null;
+      continue;
+    }
+
+    if (fence !== null) {
+      fence.push(line);
+    }
+  }
+
+  return blocks;
+}
+
+// The README's embedded diagrams, matched by content rather than by id — see the
+// header comment for why the rule is weaker there and why it still has to exist.
+const byContent = new Map(files.map((name) => [readFileSync(join(dirPath, name), 'utf8'), name]));
+const readmePath = join(repoRoot, 'README.md');
+const embedded = existsSync(readmePath) ? mermaidBlocks(readFileSync(readmePath, 'utf8')) : [];
+const embeddedNames = [];
+
+for (const [index, source] of embedded.entries()) {
+  const match = byContent.get(source);
+
+  if (match === undefined) {
+    failures.push(
+      `README.md's Mermaid block #${index + 1} is identical to no file in docs/diagrams/. `
+      + 'The README embeds a copy of a diagram, never one of its own: copy the .mmd it '
+      + 'came from verbatim, or add the diagram to docs/DIAGRAMS.md and docs/diagrams/ first.',
+    );
+    continue;
+  }
+
+  embeddedNames.push(match);
+}
+
 if (sections.length === 0) {
   console.error('check-diagrams: docs/DIAGRAMS.md declares no diagram sections. That cannot be right — failing loudly.');
   process.exit(1);
@@ -141,4 +197,10 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`check-diagrams: ${sections.length} diagram(s), each paired with docs/diagrams/ and identical.`);
+const embeddedNote = embeddedNames.length > 0
+  ? ` README.md embeds ${embeddedNames.join(', ')}, unchanged.`
+  : '';
+
+console.log(
+  `check-diagrams: ${sections.length} diagram(s), each paired with docs/diagrams/ and identical.${embeddedNote}`,
+);


### PR DESCRIPTION
> **Supersedes #33** — this branch contains #33's commit plus the correction, so close #33 and merge this one instead of both.

## What changed

The README's first figure was the confirmation card. That is the **specimen**, not the deliverable, and a repository whose own one-line summary is *"the agent is the excuse; the eval bench is the deliverable"* cannot open by drawing the excuse — a reader who stops after the first picture leaves believing this is an HR chatbot with a nice approval dialog.

The first figure is now **C1, "the measuring loop — the general picture"**, which `docs/DIAGRAMS.md` has carried all along: spec → scenarios as data → the real service run in-process → one captured trace → Layer 1 and Layer 2 → the CI gates. It is embedded as Mermaid rather than as an image, because GitHub renders Mermaid in a README the same way it does anywhere else, a diff of it is a diff of the diagram's *meaning*, and it is already this repository's idiom. Six numbered paragraphs walk the loop, each naming the file a reader opens next — the schema, `evals/README.md`, C2/C3/C6 for the internals.

The card moves down to a section that says what it is: **"The specimen: an agent that stops"**, placed after the numbers so the bench is explained before the thing it measures. It absorbs the old "The agent, in one paragraph" — one agent section rather than two — and closes on why the agent is the excuse: *"it stops for a human" is a claim, and a claim about agent behaviour is worth exactly what its measurement is worth.*

Section order is now: what it is → **how the bench works** → the numbers → the specimen → run it → judge it → where to read next → why → the integration target → built vs never-run → layout → standards → non-goals.

## Why

Embedding the diagram creates a **third** copy of it, and this repository's stated answer to a drift surface is never "remember to update both" — it is a check that fails. `check-diagrams.mjs` therefore grows a third rule: every ` ```mermaid ` block in `README.md` must be byte-identical to some file in `docs/diagrams/`.

The README has no numbered `### C1.` sections to join on, so the match is by **content** rather than by id. That is deliberately weaker than the join used for `DIAGRAMS.md`, and it is still mechanical: you cannot edit one copy without the check noticing, and you cannot invent a README-only diagram that lives nowhere else. The header comment says both of those things so the next reader does not have to infer the asymmetry.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched

## Eval impact

No eval-triggering paths touched: nothing under `evals/`, `prompts/` or `agents/` changed.

**Scenario / criteria diff vs baseline:** no eval-triggering paths touched.

## Verification

`dotnet` is not available in this environment, so the .NET half is left for CI rather than reported as done. No `.cs` file is changed by either commit on this branch.

- [x] `npm run lint` green:

  ```text
  Summary: 0 issues in 0 files
  check-links: 313 relative link(s) across 41 Markdown file(s) — all resolve.
  check-diagrams: 22 diagram(s), each paired with docs/diagrams/ and identical. README.md embeds c1-eval-loop.mmd, unchanged.
  check-doc-parity: 8 bilingual document(s), both halves present.
  validate-scenarios: 35 scenarios valid.
  validate-agent-definitions: 1 definition(s), schema and catalogue agree.
  ```

- [x] **The new check was proved able to fail**, which is this repository's own rule about instruments (`E2E-ACCEPTANCE-TESTING.md` §2, and the mutation pass it produced). A one-token edit to the README's embedded copy:

  ```text
  check-diagrams: FAILED

    - README.md's Mermaid block #1 is identical to no file in docs/diagrams/. The README
      embeds a copy of a diagram, never one of its own: copy the .mmd it came from
      verbatim, or add the diagram to docs/DIAGRAMS.md and docs/diagrams/ first.
  ```

- [x] `check-links` earned its place again on this diff, catching a link to `evals/scenarios/` (a directory with no `README.md`) before it was pushed
- [x] Secret scan clean — gitleaks over full history, 129 commits, with `.gitleaks.toml` and with the upstream default ruleset alone
- [ ] `dotnet build` / `dotnet test` — not run here; left to CI

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`
- [x] An existing deviation is narrowed rather than added: D-2, whose `fly.toml` half Phase 9 closed (carried from #33)

## Public-repo checks

- [x] No secrets, tokens, or credentials — including in comments and test fixtures
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

## Still not in this PR

Unchanged from #33 — three release blockers that are repository settings rather than commits:

1. **`konradcinkusz/architecture-standards` is private**, and this repository links to it 20 times across 14 files, including the sentence carrying the central claim.
2. **GitHub Pages is not enabled**, so `docs/index.html` is not served and `og:image` points at a URL that 404s.
3. **No repository topics are set.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvcoG4nZoZNPTBQXBUUpnh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvcoG4nZoZNPTBQXBUUpnh)_