### PR TITLE
A quantity stops becoming a date

### DIFF
--- a/src/AbsenceConcierge.AgentService/Agent/Language/DateExpressionParser.cs
+++ b/src/AbsenceConcierge.AgentService/Agent/Language/DateExpressionParser.cs
@@ -104,12 +104,19 @@ public static partial class DateExpressionParser
 
         // A bare number is only a day of the month when the sentence gives some
         // other reason to read it as one — an ordinal suffix somewhere, or a named
-        // month. "I need 2 days off" must not become the 2nd.
-        var bareNumbersAllowed = OrdinalPattern().IsMatch(utterance) || ContainsEnglishMonthName(utterance);
+        // month. The reason has to be allowed to travel: "19 to 21 August" names
+        // the month once, and the 19th is a date only because of a word that comes
+        // after the 21st (amb-007).
+        var bareNumbersAllowed = OrdinalPattern().IsMatch(utterance) || MonthNamePattern().IsMatch(utterance);
 
         foreach (Match match in DayOfMonthPattern().Matches(utterance))
         {
-            if (match.Groups["suffix"].Value.Length == 0 && !bareNumbersAllowed)
+            // ...but a number that counts something is a quantity whatever else the
+            // sentence says. Without this, "I need 2 days off starting the 5th"
+            // reads the 5th's ordinal as licence for the 2, and books two dates.
+            // This is positive evidence about *this* number, which is the thing a
+            // sentence-wide gate cannot express.
+            if (match.Groups["suffix"].Value.Length == 0 && (!bareNumbersAllowed || CountsSomething(utterance, match)))
             {
                 continue;
             }
@@ -345,8 +352,9 @@ public static partial class DateExpressionParser
         "july", "august", "september", "october", "november", "december",
     ];
 
-    private static bool ContainsEnglishMonthName(string utterance) =>
-        EnglishMonthNames.Any(month => utterance.Contains(month, StringComparison.OrdinalIgnoreCase));
+    // True when this number is counting rather than dating: "2 days", "3 weeks".
+    private static bool CountsSomething(string utterance, Match match) =>
+        DurationNounPattern().IsMatch(utterance.AsSpan(match.Index + match.Length));
 
     private static DayOfWeek EnglishWeekday(string name) =>
         (DayOfWeek)Array.FindIndex(
@@ -447,6 +455,17 @@ public static partial class DateExpressionParser
 
     [GeneratedRegex(@"\b\d{1,2}(st|nd|rd|th)\b", RegexOptions.IgnoreCase)]
     private static partial Regex OrdinalPattern();
+
+    // Word boundaries, not Contains: "may" is a month and "maybe" is not, "march"
+    // is a month and "marching" is not. A substring scan armed the bare-number
+    // gate on both, and read "I need 2 days off, maybe next week" as the 2nd.
+    [GeneratedRegex($@"\b(?:{Months})\b", RegexOptions.IgnoreCase)]
+    private static partial Regex MonthNamePattern();
+
+    // Anchored at the start of what follows the number, so it asks "does this
+    // number count days?" rather than "does the sentence mention days anywhere?".
+    [GeneratedRegex(@"^\s+(?:days?|weeks?|months?|hours?)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex DurationNounPattern();
 
     [GeneratedRegex($@"\b(?<day>{Weekdays})\b", RegexOptions.IgnoreCase)]
     private static partial Regex WeekdayPattern();

--- a/tests/AbsenceConcierge.AgentService.Tests/UtteranceInterpreterTests.cs
+++ b/tests/AbsenceConcierge.AgentService.Tests/UtteranceInterpreterTests.cs
@@ -172,6 +172,44 @@ public sealed class DateExpressionParserTests
         Assert.Null(DateExpressionParser.Parse("I need 2 days off at some point"));
     }
 
+    [Theory]
+    [InlineData("I need 2 days off, maybe next week")]
+    [InlineData("I need 3 days off, the band is marching")]
+    public void A_word_that_merely_contains_a_month_is_not_a_month(string utterance)
+    {
+        // The gate that licenses bare numbers used to ask Contains("may"), which
+        // "maybe" and "marching" both satisfy. One substring turned a quantity
+        // into a booking.
+        Assert.Null(DateExpressionParser.Parse(utterance));
+    }
+
+    [Fact]
+    public void An_ordinal_elsewhere_does_not_make_a_quantity_a_date()
+    {
+        // The licence used to be sentence-wide: the 5th's suffix vouched for the
+        // 2, and the turn booked both. A number a duration noun follows is
+        // counting, whatever else the sentence contains.
+        var parsed = DateExpressionParser.Parse("I need 2 days off starting the 5th");
+
+        var calendarDay = Assert.IsType<CalendarDayExpression>(parsed);
+        Assert.Equal(5, calendarDay.Day);
+    }
+
+    [Fact]
+    public void A_month_elsewhere_still_reaches_a_bare_number_that_dates()
+    {
+        // The other side of the same rule, and the regression to watch: the fix
+        // must not become "local evidence only". Nothing next to the 19 says it
+        // is a date — only August, three words later, does (amb-007).
+        var parsed = DateExpressionParser.Parse("Book 19 and 20 August off");
+
+        var list = Assert.IsType<DateListExpression>(parsed);
+        Assert.Collection(
+            list.Parts,
+            part => Assert.Equal(19, Assert.IsType<CalendarDayExpression>(part).Day),
+            part => Assert.Equal(20, Assert.IsType<CalendarDayExpression>(part).Day));
+    }
+
     [Fact]
     public void A_sentence_with_no_date_parses_to_nothing()
     {


### PR DESCRIPTION
Closes #85. Second item of Roadmap B (#69), first of the nine findings still open on #63.

## What changed

A suffix-less number is no longer read as a day of the month when it is counting something, and a word that merely *contains* a month name no longer licenses bare numbers at all.

## Why

Both halves of the gate at `DateExpressionParser.cs:108` leaked. The existing guard test — `I need 2 days off at some point` — passed only because that sentence happens to contain neither trigger.

| Utterance | Was | Now |
|---|---|---|
| `I need 2 days off, maybe next week` | booked the 2nd | no date |
| `I need 3 days off, the band is marching` | booked the 3rd | no date |
| `I need 2 days off starting the 5th` | booked the 2nd **and** the 5th | the 5th |

The first two are `Contains("may")` and `Contains("march")`, which **may**be and **march**ing satisfy. Word boundaries fix those.

**The third is the one worth reading.** The licence was computed once for the whole utterance, so the 5th's ordinal suffix vouched for an unrelated `2`.

**The obvious repair is wrong, and the corpus says so.** Requiring evidence local to each number breaks `amb-007` — *"Can I book 19 to 21 August off as vacation?"* — where nothing next to the `19` makes it a date. Only `August`, three words later, does. That back-propagation is load-bearing and already has a test.

So the sentence-wide licence stays, and a number gains the one thing a sentence-wide gate structurally cannot express: **positive evidence about itself**. A number that a duration noun follows is counting, whatever else the sentence contains.

The Spanish path never had this bug — `SpanishDayOfMonthPattern` requires an article lookbehind (`el día`/`del`/`al`/`el`) or an explicit `de <month>`. It was not copied wholesale because it also has no back-propagation.

## Spec impact

- [x] No behaviour change to the spec — `docs/SPEC.md` untouched. This corrects the interpreter against SPEC §4.1's existing boundary rather than moving it.

## Eval impact

`evals/` paths are not touched, so the suite runs unchanged and the corpus is unmodified. `amb-007` is the scenario most exposed to this change and it still parses both ends of its range.

- [x] Constraint scenarios: 100% pass
- [x] Behaviour scenarios: unchanged — full run below
- [x] No baseline re-record needed: no scenario or fixture content changed

## Verification

Everything below was run locally, on this branch:

```
dotnet build --configuration Release   1 Warning(s)  0 Error(s)
dotnet test  --configuration Release   total: 334  failed: 0  succeeded: 330  skipped: 4
npm run lint:md                        Linting: 42 files / Summary: 0 issues in 0 files
npm run lint:links                     335 relative link(s) across 44 files — all resolve
./scripts/scan-secrets.sh              no leaks found / Secret scan clean.
```

The single warning is the pre-existing `ASPIRE010` on the AppHost, present on `main` too. The four skips are the three no-credential Layer 2 tests and the opt-in narrative dump.

**The four new tests were checked against code that lacks the fix, rather than assumed to check something** — this repository's own rule that a real assertion "only proves it can pass, not that it can catch anything":

- reverting `DateExpressionParser.cs` alone → **3 of 4 fail** (the two substring cases and the sentence-global one)
- reducing the gate to local evidence only → the back-propagation guard **and** the existing `A_range_of_ordinals_carries_the_month_back_to_the_first_end` **both fail**, which is the mistake that guard exists to catch

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01E29Lw3qVi1pEUVbg2duobm)_