### PR TITLE
Naming anyone no longer switches the cross-language fallback off

### DIFF
--- a/src/AbsenceConcierge.AgentService/Agent/Language/DeterministicUtteranceInterpreter.cs
+++ b/src/AbsenceConcierge.AgentService/Agent/Language/DeterministicUtteranceInterpreter.cs
@@ -114,14 +114,37 @@ public sealed partial class DeterministicUtteranceInterpreter : IUtteranceInterp
             claimsApproval);
     }
 
+    /// <summary>
+    /// "Did <i>this language</i> read anything?" — which is a narrower question than
+    /// "is this intent blank?", and the difference is the whole of the fallback.
+    ///
+    /// <para>
+    /// A <see cref="PersonRole.Mention"/> is not an answer to it. Subject and
+    /// DateReference come from language-specific markers — <c>for</c> against
+    /// <c>para</c> — so finding one is evidence the sentence was read. A Mention
+    /// comes from <c>NameLikePattern</c>, which takes no language and matches any
+    /// capitalised word, so <b>both</b> readings always find it. Counting it as
+    /// content made the first reading non-empty for every sentence that names
+    /// anybody, and the fallback never ran: an es-ES locale reading "Book Friday
+    /// off for Sam" returned Unclear with no date, discarding a perfectly good
+    /// English reading — and downgrading Sam from Subject to Mention, so the scope
+    /// guard saw a passing reference where the sentence asked to book for someone
+    /// else.
+    /// </para>
+    ///
+    /// <para>
+    /// Nothing is lost when both languages find only a Mention: the caller returns
+    /// the primary reading when the fallback is empty too, so the name survives.
+    /// </para>
+    /// </summary>
     private static bool IsEmpty(Intent intent) =>
         intent is
         {
             Kind: IntentKind.Unclear,
             Dates: null,
             LeaveTypeHint: null,
-            Person: null,
             ClaimsPriorApproval: false,
+            Person: null or { Role: PersonRole.Mention },
         };
 
     /// <summary>

--- a/tests/AbsenceConcierge.AgentService.Tests/SpanishInterpretationTests.cs
+++ b/tests/AbsenceConcierge.AgentService.Tests/SpanishInterpretationTests.cs
@@ -325,4 +325,49 @@ public sealed class SpanishInterpretationTests
 
         Assert.Equal(IntentKind.CancelOrEditBooking, intent.Kind);
     }
+
+    [Fact]
+    public void A_named_spanish_sentence_on_an_english_deployment_still_reads()
+    {
+        // Naming someone used to switch the fallback off. NameLikePattern takes no
+        // language, so the English reading of this sentence found "Sam Rivera" as a
+        // bare Mention, that counted as content, and the Spanish reading — which
+        // has the intent, the date and the actual role — was never consulted.
+        var intent = DeterministicUtteranceInterpreter.InterpretWithFallback(
+            "Necesito el 3 de marzo libre para Sam Rivera",
+            UtteranceLanguage.English);
+
+        Assert.Equal(IntentKind.RequestTimeOff, intent.Kind);
+        Assert.IsType<CalendarDayExpression>(intent.Dates);
+        Assert.Equal(new PersonReference("Sam Rivera", PersonRole.Subject), intent.Person);
+    }
+
+    [Fact]
+    public void A_named_english_sentence_on_a_spanish_deployment_still_reads()
+    {
+        // The same defect in the other direction, and the one that matters most:
+        // the person arrived as a Mention rather than a Subject, so the scope guard
+        // saw an incidental reference where the sentence asks the agent to book for
+        // somebody else (O-3).
+        var intent = DeterministicUtteranceInterpreter.InterpretWithFallback(
+            "Book Friday off for Sam",
+            UtteranceLanguage.Spanish);
+
+        Assert.Equal(IntentKind.RequestTimeOff, intent.Kind);
+        Assert.IsType<ComingWeekdayExpression>(intent.Dates);
+        Assert.Equal(new PersonReference("Sam", PersonRole.Subject), intent.Person);
+    }
+
+    [Fact]
+    public void A_name_neither_language_can_place_is_still_reported()
+    {
+        // The other edge of the same rule, on the sentence O-3's "deliberate
+        // asymmetry" is written about. Both readings find only a Mention, so
+        // neither is evidence — but the name must not be dropped on the way out.
+        var intent = DeterministicUtteranceInterpreter.InterpretWithFallback(
+            "I'm covering for Dana Okafor",
+            UtteranceLanguage.English);
+
+        Assert.Equal(new PersonReference("Dana Okafor", PersonRole.Mention), intent.Person);
+    }
 }


### PR DESCRIPTION
Closes #87. Roadmap B (#69), second of the nine findings still open on #63.

## What changed

`IsEmpty` no longer counts a bare `PersonRole.Mention` as content, so a sentence that names someone can still fall back to the other language.

## Why

`InterpretWithFallback` tries the other language only when the locale's language read nothing at all, and `IsEmpty` decided what "nothing" meant. It counted `Person`, and `Person` leaks.

`FindPerson` has three paths. Two are language-specific — `for` against `para`, `as` against `como` — so finding one is genuine evidence the sentence was read. The third is `NameLikePattern`, which **takes no language** and matches any non-sentence-initial capitalised word. Both readings always find it.

So every sentence naming anybody produced a non-empty first reading, and the fallback never ran:

| Locale | Utterance | Got | Lost |
|---|---|---|---|
| `es-ES` | `Book Friday off for Sam` | Unclear, no date, Sam as a **Mention** | RequestTimeOff, the coming Friday, Sam as the **Subject** |
| `en-GB` | `Necesito el 3 de marzo libre para Sam Rivera` | Unclear, no date | RequestTimeOff and the 3rd of March |
| `en-GB` | `Estoy enfermo, necesito el martes libre para Sam` | Unclear, no date, no hint | RequestTimeOff, the coming Tuesday, `sick` |

The control pins the cause on the name rather than the vocabulary — the same kind of sentence **without** a name already fell back correctly:

```
[English] "Quiero vacaciones el lunes"
  primary : Unclear, no date
  fallback: RequestTimeOff, ComingWeekday, Hint=vacation     ← already worked
```

**The role downgrade is the worse half.** Sam arrives as a `Mention` instead of a `Subject`, so `ScopeGuardStep` sees someone mentioned in passing where the sentence actually asks the agent to book leave for another person — and O-3 is precisely the constraint that reading is meant to trigger. A silent failure on the third-party-booking family is a poor place for one.

`IsEmpty` now asks the narrower question it was always meant to ask — *did **this language** read anything?* — and a name both languages find is not an answer. Nothing is dropped when both readings are Mention-only: `InterpretWithFallback` already returns the primary reading when the fallback is empty too.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched. This makes the interpreter meet SPEC §9's existing locale rule; the rule itself is unchanged.

## Eval impact

`evals/` paths are not touched; the corpus and fixtures are unmodified, so no baseline re-record.

- [x] Constraint scenarios: 100% pass
- [x] Behaviour scenarios: unchanged — full run below

Worth noting for review: this makes the agent read *more* sentences as `RequestTimeOff` with a `Subject`, which means **more** O-3 refusals on mixed-locale traffic, not fewer. That is the correct direction — those turns were previously being misread as harmless — but it is a real behaviour change on the demo and worth knowing about.

## Verification

Run locally on this branch:

```
dotnet build --configuration Release   1 Warning(s)  0 Error(s)
dotnet test  --configuration Release   total: 337  failed: 0  succeeded: 333  skipped: 4
npm run lint:md                        Summary: 0 issues in 0 files
npm run lint:links                     335 relative link(s) across 44 files — all resolve
./scripts/scan-secrets.sh              Secret scan clean.
```

The one warning is the pre-existing `ASPIRE010` on the AppHost, present on `main`. The four skips are the three no-credential Layer 2 tests and the opt-in narrative dump.

**Tests checked against the unfixed code**, per this repository's rule that an assertion only proves it can pass unless you show it can fail: reverting `IsEmpty` alone makes the two directional tests fail. The third — `A_name_neither_language_can_place_is_still_reported` — passes both before and after by design; it pins behaviour the fix must not break (a Mention-only reading in both languages still reaches the caller with the name), rather than detecting the bug. It uses `I'm covering for Dana Okafor`, which is the sentence O-3's "deliberate asymmetry" is written about.

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials
- [x] No real personal data; fixtures are fictional
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01E29Lw3qVi1pEUVbg2duobm)_