### PR TITLE
The scenario schema stops accepting a tool that does not exist

### DIFF
--- a/evals/schema/scenario.schema.json
+++ b/evals/schema/scenario.schema.json
@@ -61,8 +61,8 @@
         },
         "timezone": {
           "type": "string",
-          "pattern": "^[A-Za-z]+/[A-Za-z_+-]+$",
-          "description": "IANA zone for the acting user. Date resolution happens here, not in UTC."
+          "pattern": "^[A-Za-z_]+(?:/[A-Za-z0-9_+-]+){1,2}$",
+          "description": "IANA zone for the acting user. Date resolution happens here, not in UTC. Two or three components, because a two-component pattern rejects America/Argentina/Buenos_Aires and America/Indiana/Indianapolis — it was enforcing the shape of the one zone the corpus happened to use, not a property of IANA zones."
         },
         "locale": { "type": "string", "pattern": "^[a-z]{2}(-[A-Z]{2})?$" },
         "overrides": {
@@ -73,6 +73,10 @@
         "tool_behaviour": {
           "type": "object",
           "description": "Fault injection per tool, for the degradation class. Absent means every tool succeeds.",
+          "propertyNames": {
+            "enum": ["get_current_user", "find_employee", "list_leave_types", "list_leaves", "request_time_off"],
+            "description": "The tool catalogue from SPEC.md 2.1, closed. An unconstrained key means a typo — list_leave_typez — validates, injects nothing, and leaves the degradation scenario built around it running against a world where everything succeeds. It then passes, because a scenario asserting a graceful degradation path is satisfied by a turn that never degraded: a green eval that checked nothing."
+          },
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,

--- a/scripts/validate-scenarios.mjs
+++ b/scripts/validate-scenarios.mjs
@@ -331,3 +331,66 @@ if (empty.length > 0) {
   console.error('All five classes are mandatory (AI-EVALS.md §3).');
   process.exit(1);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  The schema proves it can reject.
+//
+//  Everything above shows the schema accepts 37 good documents, which is the
+//  half that cannot fail. E2E-ACCEPTANCE-TESTING.md §2 is blunt about what that
+//  is worth: a real assertion "only proves it can pass — not that it can catch
+//  anything", and AI-EVALS.md §9 now says the same for eval suites. A schema is
+//  an assertion about every scenario anyone will ever write, so it earns the
+//  same treatment.
+//
+//  Each case below was a hole. `list_leave_typez` validated, injected no fault,
+//  and left a degradation scenario running against a world where everything
+//  succeeded — passing, because a scenario asserting graceful degradation is
+//  satisfied by a turn that never degraded.
+// ─────────────────────────────────────────────────────────────────────────────
+const REJECTION_CASES = [
+  {
+    what: 'a tool name that does not exist',
+    mutate: (f) => ({ ...f, tool_behaviour: { list_leave_typez: { outcome: 'timeout' } } }),
+  },
+  {
+    what: 'an unknown key inside a tool behaviour',
+    mutate: (f) => ({ ...f, tool_behaviour: { list_leave_types: { outcome: 'timeout', nope: 1 } } }),
+  },
+  {
+    what: 'a tool behaviour with no outcome',
+    mutate: (f) => ({ ...f, tool_behaviour: { list_leave_types: { latency_ms: 10 } } }),
+  },
+  { what: 'a timezone that is not a zone', mutate: (f) => ({ ...f, timezone: 'not a zone' }) },
+  { what: 'a timezone path too deep to be one', mutate: (f) => ({ ...f, timezone: 'A/B/C/D' }) },
+];
+
+const specimen = parseYaml(readFileSync(files[0], 'utf8'));
+const notRejected = [];
+
+for (const { what, mutate } of REJECTION_CASES) {
+  const doc = { ...specimen, id: 'deg-000-schema-self-check', fixture: mutate(specimen.fixture) };
+  if (validate(doc)) {
+    notRejected.push(what);
+  }
+}
+
+// The converse, so the rules above cannot be satisfied by a schema that rejects
+// everything: a three-component IANA zone is legitimate and must still validate.
+// The old two-component pattern turned away America/Argentina/Buenos_Aires, which
+// was enforcing the shape of the one zone this corpus happens to use.
+if (!validate({
+  ...specimen,
+  id: 'deg-000-schema-self-check',
+  fixture: { ...specimen.fixture, timezone: 'America/Argentina/Buenos_Aires' },
+})) {
+  notRejected.push('WRONGLY REJECTED a valid three-component IANA zone');
+}
+
+if (notRejected.length > 0) {
+  console.error('\nvalidate-scenarios: the schema no longer catches:');
+  for (const what of notRejected) {
+    console.error(`  → ${what}`);
+  }
+  console.error('\nA schema that only ever accepts is a schema nobody knows works.');
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #93. Roadmap B (#69), fifth of the nine findings on #63.

## What changed

Two strictness gaps in `evals/schema/scenario.schema.json`, and a **self-check in the validator** so the schema has to keep proving it can reject.

## Why

### 1. A typo'd tool name validated, injected nothing, and passed

The #65 round closed `tool_behaviour`'s **values** — `additionalProperties: false`, `outcome` required — and left its **keys** open. So this validated:

```yaml
tool_behaviour:
  list_leave_typez:      # note the z
    outcome: timeout
```

…injected no fault, and left the degradation scenario built around it running against a world where **everything succeeded**. It then passed, because a scenario asserting a graceful degradation path is perfectly satisfied by a turn that never degraded.

That is a green eval that checked nothing — the failure this corpus exists to prevent. The tool catalogue is closed and already normative in SPEC §2.1, so `propertyNames` with an enum is the whole fix.

### 2. The timezone pattern encoded one zone's shape

`^[A-Za-z]+/[A-Za-z_+-]+$` allows two components only:

| Zone | Old | New |
|---|---|---|
| `Europe/Madrid` | pass | pass |
| `America/Argentina/Buenos_Aires` | **FAIL** | pass |
| `America/Indiana/Indianapolis` | **FAIL** | pass |
| `Etc/GMT+5` | **FAIL** | pass |
| `not a zone` / `Europe/` / `/Madrid` / `A/B/C/D` | fail | fail |

It was not enforcing a property of IANA zones; it was enforcing the shape of the one zone this corpus happens to use. An Argentine scenario would have been rejected before anyone could ask whether the agent handles it.

**Neither change breaks anything** — checked before proposing: the only `tool_behaviour` keys in the corpus are `list_leave_types` and `request_time_off`, and the only timezone anywhere is `Europe/Madrid`.

## The self-check, and how it caught itself

Validating 37 good documents only proves the schema **accepts**. A schema is an assertion about every scenario anyone will ever write, and both `E2E-ACCEPTANCE-TESTING.md` §2 and now `AI-EVALS.md` §9 say an assertion never shown to fail is worth little. So `validate-scenarios.mjs` now mutates a real scenario five ways and requires each to be rejected, plus the converse: a legitimate three-component zone must still validate.

**The converse earned its place immediately.** My first version used the id `probe-000-schema-self-check`, which fails the id pattern's `[a-z]{3,4}` prefix — `probe` is five letters. So every probe document was being rejected **on its id rather than on the mutation**, and all five rejection cases were passing for the wrong reason. Only the converse case failed, and that is what exposed it.

A self-check that caught itself on its first run is the argument for having one, and it is the same false-green this PR is otherwise about.

There is no Node test runner in this repo (Playwright covers e2e only), so the check lives inside the validator that already runs in CI via `validate:scenarios` — no new infrastructure.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched. The schema now enforces what §2.1's tool table already said.

## Eval impact

No scenario, fixture or rubric content changed; the corpus is byte-identical and no baseline re-record is needed.

- [x] Constraint scenarios: 22 of 22 pass
- [x] Behaviour scenarios: 15, unchanged

## Verification

```
npm run lint                          full chain green (md, links, diagrams, parity, scenarios, fixtures, agents)
node scripts/validate-scenarios.mjs   37 scenarios valid · 22 constraint · 15 behaviour · exit 0
dotnet build --configuration Release  1 Warning(s)  0 Error(s)
dotnet test  --configuration Release  total: 339  failed: 0  succeeded: 335  skipped: 4
./scripts/scan-secrets.sh             Secret scan clean.
```

**Checked against the unfixed schema**, which is the point of the whole change: reverting `scenario.schema.json` while keeping the self-check makes the validator report

```
validate-scenarios: the schema no longer catches:
  → a tool name that does not exist
  → WRONGLY REJECTED a valid three-component IANA zone
```

and **exit 1**. The other three probes stay caught on the old schema too, correctly — `additionalProperties: false`, the required `outcome`, and the old pattern's rejection of `not a zone` were all already working.

I also confirmed the hole was real rather than theoretical: a probe scenario carrying `list_leave_typez` validated clean against `main` (exit 0) before this change.

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials
- [x] No real personal data
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01E29Lw3qVi1pEUVbg2duobm)_