### PR TITLE
An extracted scenario asserts termination by decision, whatever the trace did

### DIFF
--- a/tests/AbsenceConcierge.Evals/Extraction/ScenarioExtractor.cs
+++ b/tests/AbsenceConcierge.Evals/Extraction/ScenarioExtractor.cs
@@ -62,6 +62,35 @@ public static class ScenarioExtractor
     /// </summary>
     public const string ReviewMarker = "REVIEW:";
 
+    /// <summary>
+    /// Names the turns that did not end by decision, when any did not.
+    ///
+    /// <para>
+    /// The extracted scenario asserts <c>decision</c> whatever the trace showed, so
+    /// on a trace like this it fails against the very session it came from. That is
+    /// the correct outcome — the session contains a real defect and the scenario is
+    /// the regression test for it — but a reviewer who cannot tell that apart from a
+    /// harness bug will spend the afternoon finding out. So the file says which
+    /// turns, and what they did, in the note a human is already required to read.
+    /// </para>
+    /// </summary>
+    private static string TerminationNote(TraceRecording trace)
+    {
+        var wrong = trace.Turns
+            .Where(turn => !string.Equals(
+                turn.TerminationReason,
+                AgentDiagnostics.TerminationReasons.Decision,
+                StringComparison.Ordinal))
+            .Select(turn => $"turn {turn.Index} ended as '{turn.TerminationReason}'")
+            .ToList();
+
+        return wrong.Count == 0
+            ? string.Empty
+            : $" NOTE: this scenario asserts termination by decision, as every scenario must (C-4), "
+              + $"but the trace it came from did not: {string.Join("; ", wrong)}. It will therefore fail "
+              + "against its own source until the agent is fixed, which is the point of it.";
+    }
+
     public static ScenarioFile From(ScenarioRun run, ExtractionRequest request)
     {
         ArgumentNullException.ThrowIfNull(run);
@@ -89,7 +118,8 @@ public static class ScenarioExtractor
             Title = $"{ReviewMarker} extracted from a trace on {request.Date}",
             Why = $"{ReviewMarker} this scenario records what the agent did, not yet what it should do. "
                 + "Replace this with why the behaviour below is correct — or change the assertions and "
-                + "fix the agent. A scenario that only says 'this is what happened' locks in the bug.",
+                + "fix the agent. A scenario that only says 'this is what happened' locks in the bug."
+                + TerminationNote(run.Trace),
 
             Origin = new ScenarioOrigin
             {
@@ -225,7 +255,29 @@ public static class ScenarioExtractor
         var last = trace.Turns[^1];
 
         yield return new ScenarioAssertion { Assert = "outcome", Turn = "last", Value = last.Outcome };
-        yield return new ScenarioAssertion { Assert = "termination", Reason = last.TerminationReason };
+
+        // Always `decision`, never the reason the trace happened to show.
+        //
+        // C-4 is not a property recovered from a trace; it is the requirement the
+        // trace is measured against. Every scenario in the corpus asserts
+        // `decision`, and validate-scenarios.mjs rejects a scenario without the
+        // check for exactly that reason: it must "prove the loop ended by decision
+        // rather than by hitting the iteration cap".
+        //
+        // This extractor's input is the worst-sessions upload — sessions that went
+        // wrong. Pinning the observed reason meant that a session whose last turn
+        // exhausted the cap produced a scenario REQUIRING the agent to exhaust the
+        // cap, and failing it for terminating properly. That inverts the constraint
+        // for every future run, wearing a production-trace origin, which is the
+        // provenance a reader trusts most.
+        //
+        // It also contradicted this file's own Why text three hundred lines up: a
+        // scenario that only says "this is what happened" locks in the bug.
+        yield return new ScenarioAssertion
+        {
+            Assert = "termination",
+            Reason = AgentDiagnostics.TerminationReasons.Decision,
+        };
 
         // Universal, and cheap to check: an identifier in a reply is a leak whatever
         // the scenario is about (SPEC O-7).

--- a/tests/AbsenceConcierge.Evals/ExtractionTests.cs
+++ b/tests/AbsenceConcierge.Evals/ExtractionTests.cs
@@ -1,3 +1,4 @@
+using AbsenceConcierge.AgentService.Telemetry;
 using AbsenceConcierge.Evals.Assertions;
 using AbsenceConcierge.Evals.Execution;
 using AbsenceConcierge.Evals.Extraction;
@@ -182,4 +183,59 @@ public sealed class ExtractionTests : IDisposable
     private static LoadedScenario Corpus(string id) =>
         ScenarioLoader.LoadAll().Single(scenario =>
             string.Equals(scenario.Id, id, StringComparison.Ordinal));
+    [Fact]
+    public void A_trace_that_hit_the_iteration_cap_does_not_become_a_scenario_demanding_it()
+    {
+        // The extractor reads worst-sessions uploads, so its input is sessions that
+        // went wrong. Pinning the reason the trace showed meant a session whose last
+        // turn exhausted the cap produced a scenario REQUIRING the agent to exhaust
+        // the cap — inverting C-4 for every future run, under a production-trace
+        // origin, which is the provenance a reader trusts most.
+        var run = RunWithTerminations(
+            AgentDiagnostics.TerminationReasons.Decision,
+            AgentDiagnostics.TerminationReasons.IterationCap);
+
+        var scenario = ScenarioExtractor.From(run, Request());
+
+        var termination = Assert.Single(scenario.Expect, a => a.Assert == "termination");
+        Assert.Equal(AgentDiagnostics.TerminationReasons.Decision, termination.Reason);
+
+        // …and the file says why it will fail against its own source, so a reviewer
+        // can tell a real defect from a broken harness without an afternoon of it.
+        Assert.Contains("turn 1 ended as 'iteration_cap'", scenario.Why, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_trace_that_ended_properly_gets_no_note()
+    {
+        // The other edge: the fix must not be "always rewrite and always complain".
+        var run = RunWithTerminations(
+            AgentDiagnostics.TerminationReasons.Decision,
+            AgentDiagnostics.TerminationReasons.Decision);
+
+        var scenario = ScenarioExtractor.From(run, Request());
+
+        var termination = Assert.Single(scenario.Expect, a => a.Assert == "termination");
+        Assert.Equal(AgentDiagnostics.TerminationReasons.Decision, termination.Reason);
+        Assert.DoesNotContain("NOTE:", scenario.Why, StringComparison.Ordinal);
+    }
+
+    private static ExtractionRequest Request() =>
+        new(
+            "hap-999-synthetic",
+            "happy",
+            new ScenarioFixture { Base = "meridian-labs", Clock = "2026-08-11T09:00:00+02:00", Timezone = "Europe/Madrid" },
+            [new ScenarioTurn { Role = "user", Content = "anything" }],
+            Reference: "synthetic trace, no production session involved",
+            Date: "2026-09-01");
+
+    private static ScenarioRun RunWithTerminations(params string[] reasons)
+    {
+        var turns = reasons
+            .Select((reason, index) => new TurnRecord(index, "completed", reason, "reply"))
+            .ToList();
+
+        return new ScenarioRun(TraceRecording.From([], turns), null!, []);
+    }
+
 }


### PR DESCRIPTION
Closes #96. Roadmap B (#69), sixth of the nine findings on #63.

## What changed

`ScenarioExtractor` emits `termination: decision` regardless of what the source trace showed, and names any turn that ended otherwise in the `REVIEW:` note.

## Why

The extractor pinned the assertion from one turn:

```csharp
var last = trace.Turns[^1];
yield return new ScenarioAssertion { Assert = "termination", Reason = last.TerminationReason };
```

`AssertionEvaluator.Termination` applies it to all of them, and says why:

> *Every turn, not just the last. C-4 says the loop terminates by decision — a turn that exhausted the cap halfway through a conversation has failed whatever the final turn did.*

The assertion has no `turn` field (`additionalProperties: false`, `assert` and `reason` only), so it is whole-trace by construction. #63 recorded the consequence: a mixed-reason trace extracts a scenario that fails against its own source.

## The sharper problem, which is why this is a bug rather than a wrinkle

All **37** scenarios assert `decision`. Not one asserts anything else, and `validate-scenarios.mjs` states the rule when a scenario omits the check:

> *Every scenario must prove the loop ended by decision rather than by hitting the iteration cap (C-4)*

So `iteration_cap` and `error` are values a trace can *exhibit*, never things a scenario should *require*.

This extractor's input is the worst-sessions upload — sessions that went wrong. **If the last turn of one exhausted the cap, the extractor wrote `termination: iteration_cap`: a scenario demanding the agent hit the cap, and failing it for terminating properly.** That inverts C-4 for every future run of that scenario, under a `production-trace` origin — the provenance a reader trusts most.

The file already argued against itself. Its own `Why` text reads:

> *this scenario records what the agent did, not yet what it should do … A scenario that only says "this is what happened" locks in the bug.*

That is exactly what pinning the observed reason did, on the one assertion the validator exists to make unconditional.

**So the reason is always `decision`.** C-4 is not a property recovered from a trace; it is what the trace is measured against.

When the trace disagrees, the `REVIEW:` note names the turns and their reasons. The extracted scenario still fails against its own source — which is *correct* for a session containing a real defect, since the scenario is the regression test for it — but a reviewer who cannot distinguish that from a broken harness will spend the afternoon finding out, and the note is cheaper than the afternoon.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched. This makes the extractor agree with C-4 as already written.

## Eval impact

No scenario, fixture or rubric content changed; the corpus is unmodified and no baseline re-record is needed. The change is to the extraction path, which produces *future* scenarios.

- [x] Constraint scenarios: 22 of 22 pass
- [x] Behaviour scenarios: 15, unchanged

## Verification

```
dotnet build --configuration Release   1 Warning(s)  0 Error(s)
dotnet test  --configuration Release   total: 341  failed: 0  succeeded: 337  skipped: 4
npm run lint                           full chain green
./scripts/scan-secrets.sh              Secret scan clean.
```

**Checked against the unfixed extractor:** `A_trace_that_hit_the_iteration_cap_does_not_become_a_scenario_demanding_it` fails when the pin is restored. The second test, `A_trace_that_ended_properly_gets_no_note`, passes both before and after by design — it pins that the fix is not "always rewrite and always complain", which is the way this change could have gone wrong.

Both build synthetic traces directly rather than running a scenario, because the defect is about a trace shape the corpus does not contain and could not easily be made to produce on demand.

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials
- [x] No real personal data
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01E29Lw3qVi1pEUVbg2duobm)_