### PR TITLE
A fault seam the browser suite can reach, so the degraded card is seen

### DIFF
--- a/flyio/demo.fly.toml
+++ b/flyio/demo.fly.toml
@@ -14,6 +14,16 @@
 #                            would also publish them: everything in `[env]` ends up
 #                            in the image config and in `fly config show`.
 #
+#   WorkforceTools__Faults__* Makes named tools fail on purpose, for the browser
+#                            suite. Two states of the confirmation card only exist
+#                            when a tool has failed, and Playwright cannot reach
+#                            them by typing. Absent here for the same reason as the
+#                            MCP settings and by the same mechanism: no key means
+#                            the decorator is never constructed, so this is
+#                            unreachable rather than switched off. A deployment
+#                            that set it would be injecting failures into real
+#                            traffic, and the service logs a warning saying so.
+#
 #   Llm__ApiKey              A secret, so it is set with `flyctl secrets set` and
 #                            never appears in a committed file. Absent, the live
 #                            composer is never constructed and the page says so.

--- a/src/AbsenceConcierge.AgentService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AbsenceConcierge.AgentService/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,29 @@ public sealed class WorkforceToolsOptions
 
     /// <summary>Fixture file name, without extension, under <c>fixtures/</c>.</summary>
     public string Fixture { get; set; } = "meridian-labs";
+
+    /// <summary>
+    /// Makes named tools fail, for the browser suite and nothing else.
+    ///
+    /// <para>
+    /// Two states of the confirmation card — the degradation note, and the
+    /// NOT-CHECKED conflict row — exist only when a tool has failed, and until this
+    /// existed they could be exercised in-process and never through the glass. The
+    /// eval harness injects at the same seam from a scenario's
+    /// <c>tool_behaviour</c> block; this is the same mechanism reached from
+    /// configuration, not a second one.
+    /// </para>
+    /// <para>
+    /// <b>Absent, not off, on the public deployment</b> — the same control as
+    /// <c>WorkforceTools:Mcp:*</c> (ADR-0005). <c>flyio/demo.fly.toml</c> sets no
+    /// key under here, so the decorator is never constructed there rather than
+    /// constructed and disabled. It touches tool results only: no state is written,
+    /// no gate is consulted, and the confirmation path is untouched — a
+    /// convenience endpoint that submitted would hand every adversarial scenario a
+    /// way around C-6, and this must not become the same mistake somewhere else.
+    /// </para>
+    /// </summary>
+    public Dictionary<string, ToolFault> Faults { get; set; } = [];
 }
 
 public static class WorkforceToolsMode
@@ -122,10 +145,39 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<IConfirmationTokenStore>(),
                 sp.GetRequiredService<TimeProvider>(),
                 AgentClock.ZoneFor(agent.Timezone),
-                maxReadAttempts);
+                maxReadAttempts,
+                Faults(options, logger));
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// The fault decorator, or null when no fault is configured — which is the case
+    /// on every deployment, because the setting exists for the browser suite.
+    ///
+    /// <para>
+    /// It logs at warning, loudly, for the same reason the pinned clock does: a
+    /// service quietly failing its own tools because somebody left a setting behind
+    /// is a very expensive kind of quiet.
+    /// </para>
+    /// </summary>
+    private static Func<IWorkforceTools, IWorkforceTools>? Faults(
+        WorkforceToolsOptions options,
+        ILogger logger)
+    {
+        if (options.Faults.Count == 0)
+        {
+            return null;
+        }
+
+        logger.LogWarning(
+            "{Section}:Faults is configured, so {Tools} will fail on purpose. This exists for the "
+            + "browser suite; a deployment that sets it is injecting failures into real traffic.",
+            WorkforceToolsOptions.SectionName,
+            string.Join(", ", options.Faults.Keys.Order(StringComparer.Ordinal)));
+
+        return inner => new FaultInjectingWorkforceTools(inner, options.Faults);
     }
 
     /// <summary>

--- a/src/AbsenceConcierge.AgentService/Workforce/FaultInjectingWorkforceTools.cs
+++ b/src/AbsenceConcierge.AgentService/Workforce/FaultInjectingWorkforceTools.cs
@@ -1,12 +1,19 @@
 using System.Collections.Concurrent;
-using AbsenceConcierge.AgentService.Workforce;
-using AbsenceConcierge.Evals.Scenarios;
 
-namespace AbsenceConcierge.Evals.World;
+namespace AbsenceConcierge.AgentService.Workforce;
 
 /// <summary>
-/// Applies a scenario's <c>tool_behaviour</c> block: makes one named tool fail, in a
-/// named way, optionally after succeeding a few times first.
+/// Makes one named tool fail, in a named way, optionally after succeeding a few
+/// times first.
+///
+/// <para>
+/// One mechanism, two callers. The eval harness drives it from a scenario's
+/// <c>tool_behaviour</c> block; the browser suite drives it from configuration, so
+/// the two card states that only appear when a tool fails can be seen through the
+/// glass rather than only in-process. A second injector would be a second set of
+/// semantics for "the backend returned 500", and the one the suite asserts against
+/// would be the one nobody ships.
+/// </para>
 ///
 /// <para>
 /// It sits <b>beneath</b> the instrumentation decorator, so an injected failure still
@@ -24,7 +31,7 @@ namespace AbsenceConcierge.Evals.World;
 /// </summary>
 public sealed class FaultInjectingWorkforceTools(
     IWorkforceTools inner,
-    IReadOnlyDictionary<string, ToolBehaviour> behaviours) : IWorkforceTools
+    IReadOnlyDictionary<string, ToolFault> behaviours) : IWorkforceTools
 {
     private readonly ConcurrentDictionary<string, int> _calls = new(StringComparer.Ordinal);
 
@@ -69,7 +76,7 @@ public sealed class FaultInjectingWorkforceTools(
     /// tool. Counts every call to the named tool, including the ones it lets through,
     /// because <c>after_calls</c> is about position in the sequence.
     /// </summary>
-    private ToolBehaviour? Intercept(string toolName)
+    private ToolFault? Intercept(string toolName)
     {
         if (!behaviours.TryGetValue(toolName, out var behaviour)
             || string.Equals(behaviour.Outcome, "success", StringComparison.Ordinal))
@@ -82,7 +89,7 @@ public sealed class FaultInjectingWorkforceTools(
         return call > behaviour.AfterCalls ? behaviour : null;
     }
 
-    private static ToolResult<T> Apply<T>(ToolBehaviour behaviour, T? empty) => behaviour.Outcome switch
+    private static ToolResult<T> Apply<T>(ToolFault behaviour, T? empty) => behaviour.Outcome switch
     {
         // May or may not have happened. The agent must never claim either
         // (SPEC §7.2), and must never retry it on a write.

--- a/src/AbsenceConcierge.AgentService/Workforce/ToolFault.cs
+++ b/src/AbsenceConcierge.AgentService/Workforce/ToolFault.cs
@@ -1,0 +1,18 @@
+namespace AbsenceConcierge.AgentService.Workforce;
+
+/// <summary>
+/// How one named tool should fail. A scenario's <c>tool_behaviour</c> block and the
+/// browser suite's configuration both bind to this, so "the backend returned 500"
+/// means one thing in the estate rather than one thing per test suite.
+/// </summary>
+public sealed class ToolFault
+{
+    /// <summary>success · timeout · http_500 · http_429 · http_403 · empty · malformed.</summary>
+    public string Outcome { get; set; } = "success";
+
+    /// <summary>Succeed this many times first, then fail. Models the tool that dies mid-conversation.</summary>
+    public int AfterCalls { get; set; }
+
+    /// <summary>Declared, not slept through — see <c>docs/SPEC.md</c> §8.1.</summary>
+    public int LatencyMs { get; set; }
+}

--- a/tests/AbsenceConcierge.AgentService.Tests/DemoModeTests.cs
+++ b/tests/AbsenceConcierge.AgentService.Tests/DemoModeTests.cs
@@ -1,4 +1,8 @@
 using AbsenceConcierge.AgentService.Agent;
+using AbsenceConcierge.AgentService.Extensions;
+using AbsenceConcierge.AgentService.Workforce;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using AbsenceConcierge.AgentService.Agent.Llm;
 using AbsenceConcierge.AgentService.Demo;
 using Microsoft.Extensions.Options;
@@ -310,6 +314,81 @@ public sealed class DemoModeTests
         budget.TryReserve(50);
         return budget;
     }
+
+    // ── The fault seam ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("http_500", false)]
+    public async Task A_tool_fails_only_when_a_fault_is_configured_for_it(string? outcome, bool expectSuccess)
+    {
+        // Asserted through behaviour, not through the resolved type. The fault
+        // decorator sits BENEATH the instrumentation one — WorkforceToolsFactory
+        // wraps whatever it decorates — so `IsNotType<FaultInjectingWorkforceTools>`
+        // is trivially true whether the seam is on or off, and a test asserting it
+        // passes with the gate forced open. Calling the tool is the only question
+        // that has a different answer.
+        var settings = new Dictionary<string, string?>
+        {
+            ["WorkforceTools:Fixture"] = "meridian-labs",
+            ["Demo:MaxConfirmationTokens"] = "8",
+        };
+
+        if (outcome is not null)
+        {
+            settings["WorkforceTools:Faults:list_leaves:Outcome"] = outcome;
+        }
+
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddWorkforceTools(new ConfigurationBuilder().AddInMemoryCollection(settings).Build());
+
+        services.Configure<AgentOptions>(_ => { });
+        services.Configure<DemoOptions>(_ => { });
+
+        using var provider = services.BuildServiceProvider();
+
+        var result = await provider.GetRequiredService<IWorkforceTools>()
+            .ListLeavesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectSuccess, result.IsSuccess);
+    }
+
+    [Fact]
+    public void The_public_deployment_carries_no_fault_configuration()
+    {
+        // Unreachable rather than switched off, and this is the assertion that
+        // keeps it that way. A future edit that adds a fault to the demo would
+        // otherwise be a one-line change with no test between it and production.
+        var config = File.ReadAllText(DemoFlyToml());
+
+        // Only the [env] block matters, and the search is anchored to the start of
+        // a line: the header comment above it discusses `[env]` in prose, and
+        // names this very setting on purpose to explain why it is absent — so an
+        // unanchored search finds the explanation and fails on it.
+        var section = config.IndexOf("\n[env]", StringComparison.Ordinal);
+        Assert.True(section >= 0, "demo.fly.toml has no [env] section.");
+
+        var env = config[section..];
+
+        // The configuration key, not the word. "Faults" case-insensitively is also
+        // inside "defaults", which this file says twice — the same substring trap
+        // that let "maybe" arm the date parser's bare-number gate.
+        Assert.DoesNotContain("WorkforceTools__Faults", env, StringComparison.Ordinal);
+    }
+
+    private static string DemoFlyToml()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "AbsenceConcierge.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return Path.Combine(directory!.FullName, "flyio", "demo.fly.toml");
+    }
 }
 
 /// <summary>A clock a test can move, for the one behaviour that is about time passing.</summary>
@@ -320,4 +399,5 @@ public sealed class MovableTimeProvider(DateTimeOffset start) : TimeProvider
     public override DateTimeOffset GetUtcNow() => _now;
 
     public void Advance(TimeSpan by) => _now = _now.Add(by);
+
 }

--- a/tests/AbsenceConcierge.Evals/Execution/ScenarioRunner.cs
+++ b/tests/AbsenceConcierge.Evals/Execution/ScenarioRunner.cs
@@ -6,9 +6,10 @@ using AbsenceConcierge.AgentService.Extensions;
 using AbsenceConcierge.AgentService.Telemetry;
 using AbsenceConcierge.AgentService.Workforce;
 using AbsenceConcierge.AgentService.Workforce.Confirmation;
+using AbsenceConcierge.Evals.World;
 using AbsenceConcierge.AgentService.Workforce.Fixtures;
 using AbsenceConcierge.Evals.Scenarios;
-using AbsenceConcierge.Evals.World;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/tests/AbsenceConcierge.Evals/Scenarios/ScenarioModel.cs
+++ b/tests/AbsenceConcierge.Evals/Scenarios/ScenarioModel.cs
@@ -1,3 +1,4 @@
+using AbsenceConcierge.AgentService.Workforce;
 using YamlDotNet.Serialization;
 
 namespace AbsenceConcierge.Evals.Scenarios;
@@ -56,20 +57,7 @@ public sealed class ScenarioFixture
     // YAML node level by FixtureComposer, because a round trip through .NET types
     // would change scalar styles and quietly turn a quoted date into something else.
 
-    public Dictionary<string, ToolBehaviour> ToolBehaviour { get; set; } = [];
-}
-
-/// <summary>Fault injection for one tool, from a scenario's <c>tool_behaviour</c> block.</summary>
-public sealed class ToolBehaviour
-{
-    /// <summary>success · timeout · http_500 · http_429 · http_403 · empty · malformed.</summary>
-    public string Outcome { get; set; } = "success";
-
-    /// <summary>Succeed this many times first, then fail. Models the tool that dies mid-conversation.</summary>
-    public int AfterCalls { get; set; }
-
-    /// <summary>Declared, not slept through — see <c>docs/SPEC.md</c> §8.1.</summary>
-    public int LatencyMs { get; set; }
+    public Dictionary<string, ToolFault> ToolBehaviour { get; set; } = [];
 }
 
 public sealed class ScenarioTurn

--- a/tests/e2e/playwright.config.mjs
+++ b/tests/e2e/playwright.config.mjs
@@ -48,6 +48,21 @@ function chromium() {
 const port = Number(process.env.E2E_PORT ?? 5233);
 const baseURL = `http://127.0.0.1:${port}`;
 
+// A second service, identical but for one setting: list_leaves fails. Two states
+// of the confirmation card — the degradation note, and the NOT-CHECKED conflict
+// row — exist only when a tool has failed, and no amount of typing at the first
+// server produces them.
+//
+// A second server rather than a per-request switch: a runtime surface that makes
+// tools fail on demand is one more thing reachable from the network on a public
+// page, and the service already refuses to expose a submit endpoint for exactly
+// that kind of reason. This one is a process that exists for ninety seconds on a
+// developer's machine.
+const faultPort = Number(process.env.E2E_FAULT_PORT ?? 5234);
+const faultBaseURL = `http://127.0.0.1:${faultPort}`;
+
+export { faultBaseURL };
+
 export default defineConfig({
   testDir: here,
   outputDir: join(here, '.artifacts'),
@@ -73,7 +88,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
   },
 
-  webServer: {
+  webServer: [{
     command: [
       'dotnet run',
       '--project', join(repoRoot, 'src', 'AbsenceConcierge.AgentService'),
@@ -123,4 +138,35 @@ export default defineConfig({
       Demo__RequestsPerMinutePerClient: '52',
     },
   },
+  {
+    command: [
+      'dotnet run',
+      '--project', join(repoRoot, 'src', 'AbsenceConcierge.AgentService'),
+      '--configuration', 'Release',
+      '--no-build',
+      '--no-launch-profile',
+    ].join(' '),
+    url: `${faultBaseURL}/health`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+
+    env: {
+      ASPNETCORE_ENVIRONMENT: 'Production',
+      ASPNETCORE_URLS: faultBaseURL,
+      WorkforceTools__Mode: 'Mock',
+      WorkforceTools__Fixture: 'e2e-showcase',
+      Agent__Timezone: 'Europe/Madrid',
+      Agent__PinnedUtcNow: '2026-08-11T09:15:00+02:00',
+      Demo__MaxTurnsPerConversation: '8',
+      Demo__RequestsPerMinutePerClient: '52',
+
+      // The one difference, and it is deg-002's fault exactly: the conflict
+      // check is what breaks. Everything else in the pipeline works, so the
+      // card that comes back is a precise statement about one phase — which is
+      // what makes both rows assertable in a single turn rather than two.
+      WorkforceTools__Faults__list_leaves__Outcome: 'http_500',
+    },
+  }],
 });

--- a/tests/e2e/showcase.spec.mjs
+++ b/tests/e2e/showcase.spec.mjs
@@ -12,6 +12,8 @@
 
 import { test, expect } from '@playwright/test';
 
+import { faultBaseURL } from './playwright.config.mjs';
+
 // The hostile leave type name the e2e fixture carries, verbatim. The YAML
 // folds its two source lines with a single space (>- scalar).
 const HOSTILE_NAME =
@@ -340,5 +342,73 @@ test.describe('the response itself', () => {
     // the sentence, not a blank.
     await send(page, 'one more');
     await expect(page.locator('#turns li').last()).toContainText('Too many requests');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  The two card states that only exist when a tool has failed.
+//
+//  These were the remainder recorded on #63: "the degradation note and the
+//  NOT-CHECKED conflict state still need fault injection the demo service does
+//  not expose." Both are rendered by app.js and, until the seam existed, neither
+//  had ever been through a browser — so the CSS-versus-`hidden` defect that F-12
+//  found on the excluded and certificate rows could have been sitting in this
+//  one the whole time and no backend test could have seen it.
+//
+//  Against the second server, whose only difference is that `list_leaves` fails.
+//  One turn produces both rows, because the conflict check is the phase that
+//  breaks: the lookup that would have found an overlap is the lookup that failed.
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('the card when a tool has failed', () => {
+  test.use({ baseURL: faultBaseURL });
+
+  test('a failed conflict lookup shows the degradation note and says the overlap is unknown', async ({ page }) => {
+    await page.goto('/');
+    await send(page, "I'm sick today and probably tomorrow");
+
+    await expect(page.locator('#card')).toBeVisible();
+
+    // NOT-CHECKED, shown rather than hidden. The wording matters more than the
+    // state name: "an overlap is unknown" is the honest thing to put in front of
+    // somebody about to approve, and "Checked — nothing overlaps" would be a
+    // false statement produced by a lookup that never ran.
+    await expect(page.locator('#card-conflicts')).toHaveText(/NOT CHECKED/);
+    await expect(page.locator('#card-conflicts')).toHaveText(/overlap is unknown/);
+
+    // The degradation note, shown, naming the phase rather than apologising
+    // generally. B-15 and §7: partial output with an explicit note.
+    const degraded = page.locator('#card-degraded');
+    await expect(degraded).toBeVisible();
+    await expect(degraded).toHaveText(/Drafted without/);
+
+    // And the gate still holds while it says all that: a degraded draft is
+    // still a draft, and the card is still waiting to be answered.
+    await expect(page.locator('#approve')).toBeVisible();
+  });
+
+  test('the degraded card is still approvable, and approving writes exactly once', async ({ page }) => {
+    await page.goto('/');
+    await send(page, "I'm sick today and probably tomorrow");
+
+    await expect(page.locator('#card-degraded')).toBeVisible();
+
+    const [response] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/agent/turn')),
+      page.click('#approve'),
+    ]);
+
+    // The point of surfacing a degradation rather than refusing: the user gets
+    // to decide with the gap in front of them. C-6 is a confirmation, not a
+    // promise that everything was checkable.
+    //
+    // `completed` is only reachable through ExecuteWriteStep against a redeemed
+    // token, so it is the write's receipt. Read from the turn rather than from
+    // /workforce/leaves, because that inspection route reads the same tool this
+    // server is failing — asking it here would be asking the broken thing
+    // whether it worked.
+    const { turn } = await response.json();
+    expect(turn.outcome).toBe('completed');
+
+    await expect(page.locator('#card')).toBeHidden();
   });
 });


### PR DESCRIPTION
Closes #75. Roadmap B (#69) — the phase's own named sub-issue, and the remainder recorded on #63's status comment.

## What changed

`FaultInjectingWorkforceTools` moves from the eval harness into the service, and the browser suite drives it from configuration against a second server. The two card states that only exist after a tool failure are now asserted through the glass.

## Why

The degradation note and the NOT-CHECKED conflict row are rendered by `app.js` and had **never been through a browser**. That matters concretely: **F-12 was exactly this shape** — a CSS rule silently defeating the `hidden` attribute on two *other* optional rows, invisible to every backend test. The same defect could have been sitting in these two the whole time.

## One mechanism, not two

The issue asked for reuse rather than a second injector, and that is what this does: the eval harness drives it from a scenario's `tool_behaviour` block, the browser suite from configuration. A second injector would mean two sets of semantics for "the backend returned 500", and the one the suite asserts against would be the one nobody ships. `ToolBehaviour` becomes `ToolFault` and moves with it, so there is one options bag rather than a twin to keep in step.

**Nothing new was invented at the seam.** `WorkforceToolsFactory.Build/Instrument` has taken an optional `decorate` since the harness needed one, so this is configuration reaching a hook that already existed.

## Absent, not off

The same control as `WorkforceTools__Mcp__*` (ADR-0005): no key means the decorator is never constructed. `flyio/demo.fly.toml` now names the setting in its own list of things it deliberately does not set, and the service logs a warning when it *is* present — for the reason the pinned clock does, that a service quietly failing its own tools because somebody left a setting behind is an expensive kind of quiet.

It touches tool results only: no state written, no gate consulted. The service refuses to expose an HTTP route that submits, because a convenience endpoint would hand every adversarial scenario a way around C-6 — which is also why the browser tests run against a **second process** rather than a per-request switch reachable from a public page.

**One fault produces both rows**, because the conflict check is the phase that breaks. It is deg-002's fault exactly (`list_leaves: http_500`), so the in-process scenario and the browser test model the same failure.

## Two things went wrong on the way

Both caught by checking rather than assuming, and both are in the diff's comments so the next person does not repeat them:

- The first version of the config guard asserted the resolved `IWorkforceTools` **was not** the fault decorator. It sits *beneath* the instrumentation decorator, so that is trivially true either way — the test **passed with the gate forced open**. It now calls the tool, which is the only question with a different answer.
- The demo-config guard matched `"Faults"` case-insensitively, which is inside **"de*faults*"** — the same substring trap that let "maybe" arm the date parser's bare-number gate in #85. It matches the configuration key now.

## Spec impact

- [x] No behaviour change — `docs/SPEC.md` untouched. No agent behaviour moves; a test affordance is added.

## Eval impact

No scenario, fixture or rubric content changed; the corpus is byte-identical and the baseline needs no re-record. The harness now reaches the decorator at its new address.

- [x] Constraint scenarios: 22 of 22 pass
- [x] Behaviour scenarios: 15, unchanged

## Verification

```
dotnet build --configuration Release   1 Warning(s)  0 Error(s)
dotnet test  --configuration Release   total: 346  failed: 0  succeeded: 342  skipped: 4
npm run test:e2e                       15 passed (15.7s)   ← was 13
npm run lint                           full chain green · 37 scenarios valid
./scripts/scan-secrets.sh              Secret scan clean.
```

**Both guards were mutation-checked:**

- adding `WorkforceTools__Faults__list_leaves__Outcome` to `demo.fly.toml` fails `The_public_deployment_carries_no_fault_configuration`
- forcing the gate shut (so fault config is ignored) fails the `http_500` case of `A_tool_fails_only_when_a_fault_is_configured_for_it`, while the no-fault case still passes

The two new e2e tests also failed usefully on their first run — against `/workforce/leaves`, which reads the very tool being failed. Asking the broken thing whether it worked; they read the turn's outcome instead.

The one warning is the pre-existing `ASPIRE010` on the AppHost.

## Standards conformance

- [x] No new deviation from `00-REFERENCE-ARCHITECTURE.md`

## Public-repo checks

- [x] No secrets, tokens, or credentials
- [x] No real personal data
- [x] No client or customer names
- [x] English only

---
_Generated by [Claude Code](https://claude.ai/code/session_01E29Lw3qVi1pEUVbg2duobm)_